### PR TITLE
Add heroku Dockerfile

### DIFF
--- a/Dockerfile.heroku
+++ b/Dockerfile.heroku
@@ -1,0 +1,23 @@
+FROM joshwlewis/docker-heroku-phoenix:latest
+
+# Compile elixir files for production
+ENV MIX_ENV prod
+# This prevents us from installing devDependencies
+ENV NODE_ENV production
+# This causes brunch to build minified and hashed assets
+ENV BRUNCH_ENV production
+
+# We add manifests first, to cache deps on successive rebuilds
+COPY ["mix.exs", "mix.lock", "/app/user/"]
+RUN mix deps.get
+
+# Again, we're caching node_modules if you don't change package.json
+ADD package.json /app/user/
+RUN npm install
+
+# Add the rest of your app, and compile for production
+ADD . /app/user/
+RUN mix compile \
+    && brunch build \
+    && mix phoenix.digest
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,18 @@ services:
       - "4000:4000"
     depends_on:
       - db
+  heroku:
+    build: .
+    command: 'bash -c ''mix phoenix.server'''
+    dockerfile: Dockerfile.heroku
+    working_directory: /app/user
+    environment:
+      LANG: en_US.UTF-8
+      HOST: localhost
+      PORT: 4000
+      # DATABASE_URL: 'postgres://db:@db:4000/api_prod'
+    ports:
+      - '4000:4000'
+    depends_on:
+      - db
+


### PR DESCRIPTION
The `Dockerfile.heroku` inherits [this](https://github.com/joshwlewis/docker-heroku-phoenix).

I opened this [issue](https://github.com/joshwlewis/docker-heroku-phoenix/issues/1) regarding the use of the Cedar-14 image.

This does not work yet.